### PR TITLE
Move modules section into kamon section

### DIFF
--- a/modules/kamon-logstash/src/main/resources/reference.conf
+++ b/modules/kamon-logstash/src/main/resources/reference.conf
@@ -33,12 +33,12 @@ kamon {
       http-server = ["**"]
     }
   }
-}
-
-modules {
-  kamon-logstash {
-    requires-aspectj = no
-    auto-start = yes
-    extension-class = "com.codekeepersinc.kamonlogstash.KamonLogstash"
+  modules {
+    kamon-logstash {
+      requires-aspectj = no
+      auto-start = yes
+      extension-class = "com.codekeepersinc.kamonlogstash.KamonLogstash"
+    }
   }
 }
+


### PR DESCRIPTION
I noticed when including the module kamon complaints: "No configuration setting found for key 'requires-aspectj'". This setting is the reference.conf but in the wrong place so cannot be used as default value.

Nice module, thanks!